### PR TITLE
LIBSEARCH-103. Removed the "aliases" keyword when loading YAML

### DIFF
--- a/config/initializers/archives_space_searcher_config.rb
+++ b/config/initializers/archives_space_searcher_config.rb
@@ -8,4 +8,4 @@ config_file = [
 ].select { |file| File.exists? file }.first
 
 QuickSearch::Engine::ARCHIVES_SPACE_CONFIG =
-  YAML.load(ERB.new(IO.read(config_file)).result, aliases: true)[Rails.env]
+  YAML.load(ERB.new(IO.read(config_file)).result)[Rails.env]


### PR DESCRIPTION
In Rails 5.2.1.1, the "aliases" keyword is no longer needed (or allowed)
when loading YAML.

https://issues.umd.edu/browse/LIBSEARCH-103